### PR TITLE
fix: replacement is wrong when there's '=' in env vars

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,8 +8,8 @@ if [ -z $FILENAME ]; then
   exit 1
 fi
 
-while IFS='=' read -r -a var; do
-  echo "Setting ${var[0]} to ${var[1]} "
-  echo ${var[1]} | wc -l
-  sed -i "s|__${var[0]}__|${var[1]}|g" $FILENAME
+while IFS='=' read -r key value; do
+  echo "Setting $key to $value "
+  echo $value | wc -l
+  sed -i "s|__$key__|$value|g" $FILENAME
 done < <(printenv)


### PR DESCRIPTION
Hi, thank you for your handy action. We found an issue happens when you have some envs like the following format
`FOO=http://example.com?token=abcd&v=1`

```
uses: falnyr/replace-env-vars-action@master
env:
  FOO: http://example.com?token=abcd&v=1
  BAR: bar
with:
  filename: /path/to/file
```

`=abcd&v=1` will be cut off and `FOO=http://example.com?token` will be wrongly stored in the given file.

This PR is to fix the above issue.

Cheers