### PR TITLE
Fix: replacement fails when value contains an ampersand

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -23,9 +23,9 @@ jobs:
         with:
           filename: ./tests/test.txt
         env:
-          NAME: mate
+          NAME: Nils & Bianca
           COLOUR: purple
       - name: Print output
         run: cat ./tests/test.txt
       - name: Test
-        run: '[[ "$(cat ./tests/test.txt)" = "Hi mate. My favourite colour is purple." ]]'
+        run: '[[ "$(cat ./tests/test.txt)" = "Hi Nils & Bianca. My favourite colour is purple." ]]'

--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 # Replace env vars in file
+
 Replaces `__TOKENS__` with environment variables in file.
 
 ## Usage
+
 #### Inputs
+
 - `filename` File for the replacement.
 
 ## Example
+
 ```yaml
 uses: falnyr/replace-env-vars-action@master
 env:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -11,5 +11,5 @@ fi
 while IFS='=' read -r -a var; do
   echo "Setting ${var[0]} to ${var[1]} "
   echo ${var[1]} | wc -l
-  sed -i "s|__${var[0]}__|${var[1]}|g" $FILENAME
+  sed -i -e "s|__${var[0]}__|$(sed 's/[&/\]/\\&/g' <<< "${var[1]}")|g" $FILENAME
 done < <(printenv)


### PR DESCRIPTION
Thanks for crafting and maintaining this very useful action. We use it a lot, but a recent deploy was corrupted, because this action could not handle a github secret that contained a `&`. This should fix it.

